### PR TITLE
添加 clipboard_monitor 到 requirements.txt 中

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ darkdetect~=0.8.0
 pynput~=1.8.1
 pillow~=11.2.1
 pystray~=0.19.5
+clipboard_monitor~=1.0.5


### PR DESCRIPTION
我发现在 `requirements.txt` 中遗漏了一个关键的库： `clipboard_monitor`.
如果没有这个库，程序将没法正确运行起来。
所以我在 `requirements.txt` 中添加了它。